### PR TITLE
feat(server): optional default for get_setting_value

### DIFF
--- a/server/helper.py
+++ b/server/helper.py
@@ -197,7 +197,7 @@ def get_setting(key):
 
 # -------------------------------------------------------------------------------
 #  Return setting value
-def get_setting_value(key):
+def get_setting_value(key, default=""):
     """
     Retrieve a setting value from configuration.
 
@@ -208,13 +208,16 @@ def get_setting_value(key):
 
     Args:
         key (str): The setting key to look up.
+        default (Any): Value to return when the key is not found. Defaults
+            to "" for backwards compatibility with call sites that already
+            treat an empty string as "missing".
 
     Returns:
-        Any: The Python-typed setting value, or an empty string if not found.
+        Any: The Python-typed setting value, or `default` if not found.
     """
 
-    # Returns empty string if not found
-    value = ""
+    # Returns default if not found
+    value = default
 
     # lookup key in secondary cache
     if key in SETTINGS_SECONDARYCACHE:


### PR DESCRIPTION
## Summary
- Add an optional `default` parameter to `get_setting_value` in `server/helper.py`.
- The parameter defaults to `""` so every existing call site keeps its current behaviour.
- New call sites can opt into a more meaningful fallback without growing the function's signature.

## Why
`get_setting_value` currently returns `""` for missing keys, which forces every caller to remember that `""` is the sentinel and to provide its own fallback. The fallback is sometimes a hard-coded default and sometimes a different code path entirely, leading to inconsistent handling.

Adding an optional `default` is the minimum change that lets call sites clean up their own fallbacks without breaking any of the ~dozens of existing callers.

## How tested
- `python -c "from helper import get_setting_value; print(get_setting_value('__nonexistent__'))"` → `''` (unchanged)
- `python -c "from helper import get_setting_value; print(get_setting_value('__nonexistent__', default=42))"` → `42` (new behaviour)
- `ruff`/`flake8` not installed in this environment; the diff is a 4-line signature/docstring change and is type-checked by the project's existing `mypy` CI.
- No automated test added in this PR; the existing `tests/` suite (if any) was not run because the project's test runner requires the full Docker stack. The change is verifiable by hand.

## Notes
- Refs #1626.
- No new dependencies, no DB or schema changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Improved settings retrieval to support customizable default values when configuration keys are not found, ensuring more predictable application behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->