### PR TITLE
fix multiple recipients in smtp plugin

### DIFF
--- a/front/plugins/_publisher_email/email_smtp.py
+++ b/front/plugins/_publisher_email/email_smtp.py
@@ -111,21 +111,21 @@ def send(pHTML, pText):
 
     mylog('debug', [f'[{pluginName}] SMTP_REPORT_TO: {hide_email(str(get_setting_value("SMTP_REPORT_TO")))} SMTP_USER: {hide_email(str(get_setting_value("SMTP_USER")))}'])
 
-    subject, from_email, to_email, message_html, message_text = sanitize_email_content(
+    to_emails = []
+
+    # handle multiple emails
+    if ',' in get_setting_value("SMTP_REPORT_TO"):
+        to_emails = get_setting_value("SMTP_REPORT_TO").split(',')
+    else:
+        to_emails.append(get_setting_value("SMTP_REPORT_TO"))
+        
+    subject, from_email, emails, message_html, message_text = sanitize_email_content(
         str(get_setting_value("SMTP_SUBJECT")),
         get_setting_value("SMTP_REPORT_FROM"),
-        get_setting_value("SMTP_REPORT_TO"),
+        to_emails,
         pHTML,
         pText
     )
-
-    emails = []
-
-    # handle multiple emails
-    if ',' in to_email:
-        emails = to_email.split(',')
-    else:
-        emails.append(to_email)
 
     mylog('debug', [f'[{pluginName}] Sending emails to {emails}'])
 
@@ -218,7 +218,7 @@ def send_email(msg, smtp_timeout):
 
 
 # ----------------------------------------------------------------------------------
-def sanitize_email_content(subject, from_email, to_email, message_html, message_text):
+def sanitize_email_content(subject, from_email, to_emails, message_html, message_text):
     # Validate and sanitize subject
     subject = Header(subject, 'utf-8').encode()
 
@@ -226,16 +226,18 @@ def sanitize_email_content(subject, from_email, to_email, message_html, message_
     from_name, from_address = parseaddr(from_email)
     from_email = Header(from_name, 'utf-8').encode() + ' <' + from_address + '>'
 
-    # Validate and sanitize recipient's email address
-    to_name, to_address = parseaddr(to_email)
-    to_email = Header(to_name, 'utf-8').encode() + ' <' + to_address + '>'
+    emails = []
+    for to_email in to_emails:
+        # Validate and sanitize recipient's email address
+        to_name, to_address = parseaddr(to_email)
+        emails.append(Header(to_name, 'utf-8').encode() + ' <' + to_address + '>')
 
     # Validate and sanitize message content
     # Remove potentially problematic characters
     message_html = re.sub(r'[^\x00-\x7F]+', ' ', message_html)
     message_text = re.sub(r'[^\x00-\x7F]+', ' ', message_text)
 
-    return subject, from_email, to_email, message_html, message_text
+    return subject, from_email, emails, message_html, message_text
 
 
 # ----------------------------------------------------------------------------------

--- a/front/plugins/_publisher_email/email_smtp.py
+++ b/front/plugins/_publisher_email/email_smtp.py
@@ -118,6 +118,14 @@ def send(pHTML, pText):
         to_emails = get_setting_value("SMTP_REPORT_TO").split(',')
     else:
         to_emails.append(get_setting_value("SMTP_REPORT_TO"))
+
+    # remove empty array entries
+    to_emails = [x for x in to_emails if x]
+
+    # throw error if array empty
+    if not to_emails:
+        mylog('none', [f'[Email Check Config] ⚠ ERROR: Email service not set up correctly. Check your {confFileName} SMTP_REPORT_TO variable.'])
+        return False
         
     subject, from_email, emails, message_html, message_text = sanitize_email_content(
         str(get_setting_value("SMTP_SUBJECT")),

--- a/front/plugins/_publisher_email/email_smtp.py
+++ b/front/plugins/_publisher_email/email_smtp.py
@@ -213,7 +213,7 @@ def send_email(msg, smtp_timeout):
         smtp_connection.login(get_setting_value('SMTP_USER'), get_setting_value('SMTP_PASS'))
 
     mylog('debug', ['Sending .sendmail()'])
-    smtp_connection.sendmail(get_setting_value("SMTP_REPORT_FROM"), get_setting_value("SMTP_REPORT_TO"), msg.as_string())
+    smtp_connection.sendmail(get_setting_value("SMTP_REPORT_FROM"), msg['To'], msg.as_string())
     smtp_connection.quit()
 
 

--- a/front/plugins/_publisher_email/email_smtp.py
+++ b/front/plugins/_publisher_email/email_smtp.py
@@ -119,8 +119,8 @@ def send(pHTML, pText):
     else:
         to_emails.append(get_setting_value("SMTP_REPORT_TO"))
 
-    # remove empty array entries
-    to_emails = [x for x in to_emails if x]
+    # remove empty array and whitespace only entries
+    to_emails = [x for x in to_emails if x and x.strip()]
 
     # throw error if array empty
     if not to_emails:


### PR DESCRIPTION
### Problem
When using multiple email recipients in the smtp plugin separated by `,` as suggested in the documentation, no emails are sent because the addresses break in the sanitization step.
<img width="1393" height="48" alt="grafik" src="https://github.com/user-attachments/assets/91474629-5a60-4691-bbe2-24b905ab2860" />

### Fix
I moved the splitting of the addresses in front of the sanitization and modified the sanitization of the recipient adresses to iterate over the provided array.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Email reports can now be delivered to multiple configured recipients.
  * Valid recipient addresses are individually sanitized before delivery.
  * Reports are addressed consistently to all valid recipients.

* **Bug Fixes**
  * Improved handling of comma-separated recipient lists.
  * Prevented invalid or malformed addresses from being used.
  * Reports are no longer sent when no valid recipients remain.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->