### PR TITLE
Fix: clock shows wrong timezone after header reload (#1640)

### DIFF
--- a/front/js/common.js
+++ b/front/js/common.js
@@ -88,14 +88,16 @@ function deleteCookie (cookie) {
 // -----------------------------------------------------------------------------
 // cacheStrings, getString, getLangCode moved to cache.js
 
-  const tz = getSetting("TIMEZONE") || 'Europe/Berlin';
-  const LOCALE = getSetting('UI_LOCALE') || 'en-GB';
-
 // -----------------------------------------------------------------------------
 // DateTime utilities
 // -----------------------------------------------------------------------------
 function localizeTimestamp(input) {
 
+  // Read fresh on every call (not a module-level const): getSetting() reads
+  // a localStorage cache that clearCache() wipes before reloading, so a
+  // stale/hardcoded fallback could otherwise stick for the page's lifetime. See #1640.
+  const tz = getSetting("TIMEZONE") || 'Europe/Berlin';
+  const LOCALE = getSetting('UI_LOCALE') || 'en-GB';
 
   input = String(input || '').trim();
 


### PR DESCRIPTION
tz/LOCALE were evaluated once as module-level consts at script-load time. clearCache() (the header reload button) wipes localStorage right before reloading, so that reload could read an empty settings cache, fall back to the hardcoded 'Europe/Berlin' default, and stay locked to that wrong value for the rest of the page's life. Moved the reads inside localizeTimestamp() so they're evaluated fresh on every call instead. Fixes #1640

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Timestamps now consistently reflect the latest timezone and locale settings whenever they are displayed.
  * Existing fallback behavior remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->