### PR TITLE
Fix: theme reverts to Light after header reload (#943)

### DIFF
--- a/front/js/common.js
+++ b/front/js/common.js
@@ -1385,7 +1385,9 @@ function getDevicesList()
 // -----------------------------------------------------------------------------
 // apply theme
 
-$(document).ready(function() {
+// Gated on callAfterAppInitialized() rather than raw $(document).ready, so this
+// can't race clearCache()'s reload and force-override the theme to Light. See #943.
+function applyTheme() {
   let theme = getSetting("UI_theme");
   if (theme) {
     theme = theme.replace("['","").replace("']","");
@@ -1402,6 +1404,10 @@ $(document).ready(function() {
   } else {
     setCookie("UI_theme", "Light");
   }
+}
+
+$(document).ready(function() {
+  callAfterAppInitialized(applyTheme);
 });
 
 // -----------------------------------------------------------


### PR DESCRIPTION
Theme was applied on raw $(document).ready, which fires before the async cacheSettings() call has necessarily populated the settings cache. clearCache() (the header reload button) wipes localStorage immediately before reloading, so that reload could read an empty cache and hard-override the theme to Light via setCookie, even with Dark or System configured. Gated the theme application on callAfterAppInitialized(), which is already used elsewhere for this class of race.

Fixes #943

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved theme initialization timing so the selected theme is applied reliably after the application finishes loading.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->