### PR TITLE
docs: fix typo shoudl -> should

### DIFF
--- a/docs/ADVISORY_EYES_ON_GLASS.md
+++ b/docs/ADVISORY_EYES_ON_GLASS.md
@@ -24,7 +24,7 @@ Static dashboards are the enemy of real-time response. NetAlertX allows you to f
 An MSP's focus is on what is *broken*, not what is working. Hide the noise to increase reaction speed.
 
 * **Hide Unnecessary Blocks:** Under UI Settings, disable dashboard blocks that don't provide immediate utility, such as **Online presence** or **Tiles**.
-* **Hide virtual connections:** You can specify which relationships shoudl be hidden from the main view to remove any virtual devices that are not essential from your views.
+* **Hide virtual connections:** You can specify which relationships should be hidden from the main view to remove any virtual devices that are not essential from your views.
 * **Browser Full-Screen:** Use the built-in "Full Screen" toggle in the top bar to remove browser chrome (URL bars/tabs) for a cleaner "Wallboard" look.
 
 ### 3. Creating Custom NOC Views


### PR DESCRIPTION
Corrects the misspelling `shoudl` -> `should` in `docs/ADVISORY_EYES_ON_GLASS.md`.

Documentation only, no behaviour change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Corrected a typo in the guidance about hiding virtual connections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->