### PR TITLE
Update download link for Proxmox installer

### DIFF
--- a/install/proxmox/README.md
+++ b/install/proxmox/README.md
@@ -13,7 +13,7 @@ An  installer script for deploying NetAlertX on Proxmox VE (Debian-based) system
 
 ## Download and run the installer
 ```bash
-wget https://raw.githubusercontent.com/jokob-sk/NetAlertX/refs/heads/main/install/proxmox/proxmox-install-netalertx.sh -O proxmox-install-netalertx.sh && chmod +x proxmox-install-netalertx.sh && ./proxmox-install-netalertx.sh
+wget https://raw.githubusercontent.com/netalertx/NetAlertX/refs/heads/main/install/proxmox/proxmox-install-netalertx.sh -O proxmox-install-netalertx.sh && chmod +x proxmox-install-netalertx.sh && ./proxmox-install-netalertx.sh
 ```
 
 ## 📋 What This Installer Does


### PR DESCRIPTION
Updated download link to point to new netalertx repository instead of older jokob-sk repository URL.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the Proxmox installer download instructions to use the current NetAlertX repository.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->