### PR TITLE
fix(front): make notifications page span full width

### DIFF
--- a/front/css/app.css
+++ b/front/css/app.css
@@ -1023,6 +1023,14 @@ height: 50px;
     display: flex;
 }
 
+/* The wrapper above is a flex container, so the content section shrinks to
+   its content width unless stretched; make it span the full page like the
+   other Monitoring pages (#1762). */
+#notifications .content
+{
+    width: 100%;
+}
+
 #notificationData
 {
     margin-bottom: 10px;


### PR DESCRIPTION
## 📌 Description

The notifications page content does not span the full width, unlike the other Monitoring pages (#1762). Root cause: the page wrapper `#notifications` is a flex container (`front/css/app.css`), so its child `<section class="content table-responsive">` is a flex item and shrinks to its content width instead of stretching like on the other pages.

This adds a scoped rule stretching the content section to the wrapper's full width:

```css
#notifications .content
{
    width: 100%;
}
```

Skeleton check requested in the issue: `#notifications-skeleton` is absolutely positioned with `left: 0; right: 0` (plus the same `margin: 15px` used by the other pages' skeletons), so it already covers the full page width during load and is unaffected by this change.

---

## 🔍 Related Issues

fixes #1762

---

## 📋 Type of Change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] ♻️ Code refactor
- [ ] 📚 Documentation update
- [ ] 🧪 Test addition or change
- [ ] 🔧 Build/config update
- [ ] 🚀 Performance improvement
- [ ] 🔨 CI/CD or automation
- [ ] 🧹 Cleanup / chore

---

## 📷 Screenshots or Logs (if applicable)

CSS-only change; the notifications table/box now stretches to the wrapper width, matching e.g. the Events/Presence pages.

---

## 🧪 Testing Steps

- Inspected the layout rules: `#notifications { display: flex }` makes `section.content` a shrink-to-fit flex item; adding `width: 100%` restores full width. The skeleton overlay uses `position: absolute; left: 0; right: 0`, so it remains full width during loading.
- The change is scoped to `#notifications .content` only; no other page uses this selector.
- I could not run the Selenium UI suite (`test/ui/test_ui_notifications.py`) locally as it requires a running instance; happy to adjust if CI/maintainer testing shows anything.

---

## ✅ Checklist

- [x] I have read the [Contribution Guidelines](../../CONTRIBUTING)
- [ ] I have tested my changes locally
- [x] I have updated relevant documentation (if applicable)
- [x] I have verified my changes do not break existing behavior
- [ ] If this PR adds/modifies a plugin, it passes the [Conventions Checklist](../../docs/PLUGINS_DEV.md#conventions-checklist)
- [x] I am willing to respond to requested changes and feedback

---

## 🙋 Additional Notes

If you would prefer removing `display: flex` from `#notifications` entirely instead of stretching the child, I am happy to rework — I kept the flex container in place to avoid disturbing the skeleton/spinner overlay behavior.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the Notifications page layout so its content spans the full available width, consistent with other Monitoring pages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->